### PR TITLE
fix: resolve bundle ID by exact identifier match

### DIFF
--- a/scripts/ensure-certificate.sh
+++ b/scripts/ensure-certificate.sh
@@ -330,7 +330,17 @@ if not bundle_ids:
     print(f"ERROR: No bundle ID found for {bundle_id}", file=sys.stderr)
     sys.exit(1)
 
-print(bundle_ids[0]["id"])
+# Apple's filter[identifier] is a substring match, not an exact one: querying
+# "app.horecon" also returns "app.horecon.web" (and any other identifier containing
+# the string). Blindly taking the first result can resolve to the wrong App ID, which
+# then fails profile creation with a misleading 409 "not allowed to create 'iOS' profile".
+exact_matches = [b for b in bundle_ids if b.get("attributes", {}).get("identifier") == bundle_id]
+if not exact_matches:
+    returned = ", ".join(b.get("attributes", {}).get("identifier", "?") for b in bundle_ids)
+    print(f"ERROR: No bundle ID exactly matching '{bundle_id}'. filter[identifier] returned: {returned}", file=sys.stderr)
+    sys.exit(1)
+
+print(exact_matches[0]["id"])
 PYEOF
 )
 echo "Bundle ID resource: $BUNDLE_ID_RESOURCE_ID"
@@ -472,8 +482,9 @@ PYEOF
         cat "$WORK_DIR/profile_create_response.json"
         if [ "$HTTP_CODE" = "409" ]; then
             echo ""
-            echo "This is likely a permissions issue. Ensure the App Store Connect API key has the 'Admin' or 'App Manager' role,"
-            echo "See: https://developer.apple.com/help/app-store-connect/reference/role-permissions/"
+            echo "Profile creation was rejected for App ID '$BUNDLE_IDENTIFIER' (resource $BUNDLE_ID_RESOURCE_ID). Common causes:"
+            echo "  - The resolved App ID is not an iOS App Store-eligible identifier (verify $BUNDLE_ID_RESOURCE_ID is the correct '$BUNDLE_IDENTIFIER' App ID)."
+            echo "  - The App Store Connect API key lacks the 'Admin' or 'App Manager' role: https://developer.apple.com/help/app-store-connect/reference/role-permissions/"
         fi
         exit 1
     fi


### PR DESCRIPTION
## Problem

`filter[identifier]` on Apple's `/v1/bundleIds` endpoint is a **substring match, not an exact match**. A query for `app.horecon` also returns every identifier that *contains* that string, e.g. `app.horecon.web`.

The bundle-ID lookup took `bundle_ids[0]["id"]` unconditionally, so when more than one App ID shares a prefix it could resolve to the **wrong** App ID. If that App ID isn't an eligible iOS App Store target, profile creation then fails with a confusing:

```
409 ENTITY_ERROR
"You are not allowed to create 'iOS' profile with App ID '<resource-id>'."
```

This looks like a permissions problem (and the old error hint said exactly that), but the API key, role, agreements and account are all fine — the lookup just picked the wrong identifier.

## Fix

- Select the bundle ID whose `attributes.identifier` matches the requested identifier **exactly**, instead of taking the first substring match.
- Fail with a clear error listing what `filter[identifier]` returned when no exact match exists, instead of silently using the wrong App ID.
- Rewrite the 409 hint to name the resolved App ID resource and list both real causes (wrong/ineligible App ID **or** insufficient key role), rather than implying it's always a permissions issue.

## Validation

- `bash -n scripts/ensure-certificate.sh` passes.
- Verified the selection logic against a simulated two-App-ID response (`app.horecon.web` returned first, `app.horecon` second): the old code picked the `.web` one, the new code picks the exact `app.horecon` match, and the no-exact-match path errors cleanly.