### PR TITLE
fix: emit legacy-encrypted PKCS#12 for downstream tooling compatibility

### DIFF
--- a/scripts/ensure-certificate.sh
+++ b/scripts/ensure-certificate.sh
@@ -528,7 +528,16 @@ echo "::add-mask::$KEYCHAIN_PWD"
 P12_PATH="$WORK_DIR/certificate.p12"
 
 echo "==> Packaging P12..."
-openssl pkcs12 -export \
+# OpenSSL 3 defaults to AES-256-CBC/PBKDF2 for PKCS#12. Apple's Security.framework and
+# .NET/BouncyCastle-based tooling (e.g. AppleDev.Tools, used by the MAUI provisioning
+# actions) cannot parse that and fail with "ASN1 corrupted data". Emit the legacy
+# SHA1/3DES format via -legacy when the running OpenSSL supports it (OpenSSL 3+); LibreSSL
+# has no -legacy flag and already defaults to the compatible algorithms.
+P12_LEGACY_FLAG=""
+if openssl pkcs12 -help 2>&1 | grep -q -- "-legacy"; then
+    P12_LEGACY_FLAG="-legacy"
+fi
+openssl pkcs12 -export $P12_LEGACY_FLAG \
     -in "$PEM_CERT_PATH" \
     -inkey "$PRIVATE_KEY_PATH" \
     -out "$P12_PATH" \


### PR DESCRIPTION
## Problem

The action packages the distribution certificate into a P12 with bare OpenSSL 3 defaults:

```bash
openssl pkcs12 -export -in ... -inkey ... -out ... -passout ...
```

OpenSSL 3 encrypts PKCS#12 with **AES-256-CBC / PBKDF2** by default. Apple's `Security.framework` and .NET/BouncyCastle-based parsers cannot read that format. In practice this surfaces downstream: a consuming workflow that feeds this P12 into `maui-actions/apple-provisioning` (which shells out to `AppleDev.Tools`) crashes while installing provisioning profiles:

```
Installing Provisioning Profiles for: app.horecon...
Error: ASN1 corrupted data.
```

No profiles get installed, and the subsequent `dotnet publish` fails with:

```
error : The specified iOS provisioning profile 'PIPE: ... AppStore' could not be found
```

This is the well-known OpenSSL 3 PKCS#12 incompatibility (see dotnet/maui#21569).

## Fix

Emit the **legacy SHA1/3DES** PKCS#12 format that every consumer (Security.framework, .NET, BouncyCastle) can read, by passing `-legacy` when the running OpenSSL supports it:

```bash
P12_LEGACY_FLAG=""
if openssl pkcs12 -help 2>&1 | grep -q -- "-legacy"; then
    P12_LEGACY_FLAG="-legacy"
fi
openssl pkcs12 -export $P12_LEGACY_FLAG ...
```

`-legacy` exists only on OpenSSL 3+; LibreSSL (which has no such flag) already defaults to the compatible algorithms, so the guard keeps it portable across both.

## Validation

- `bash -n scripts/ensure-certificate.sh` passes.
- Verified `openssl pkcs12 -help` lists `-legacy` on OpenSSL 3 (flag applied) and the guard leaves it empty otherwise.